### PR TITLE
Redisent fails to properly return bulk replies larger than 1024 bytes.

### DIFF
--- a/redisent.php
+++ b/redisent.php
@@ -82,15 +82,15 @@ class Redisent {
 				break;
 			/* Bulk reply */
 			case '$':
+				$response = null;
 				if ($reply == '$-1') {
-					$response = null;
 					break;
 				}
 				$read = 0;
 				$size = substr($reply, 1);
 				do {
 					$block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
-					$response = fread($this->__sock, $block_size);
+					$response .= fread($this->__sock, $block_size);
 					$read += $block_size;
 				} while ($read < $size);
 				fread($this->__sock, 2); /* discard crlf */


### PR DESCRIPTION
Redisent has a bug which only returns the last 1024 byte chunk of a Redis bulk response if the response is larger than 1024 bytes.

Bug discovered during use of php-resque.
https://github.com/chrisboulton/php-resque
