### PR TITLE
fread() warning fix when reading existing empty string

### DIFF
--- a/redisent.php
+++ b/redisent.php
@@ -96,11 +96,13 @@ class Redis {
 				}
 				$read = 0;
 				$size = substr($reply, 1);
-				do {
-					$block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
-					$response .= fread($this->__sock, $block_size);
-					$read += $block_size;
-				} while ($read < $size);
+				if ($size > 0){
+					do {
+						$block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
+						$response .= fread($this->__sock, $block_size);
+						$read += $block_size;
+					} while ($read < $size);
+				}
 				fread($this->__sock, 2); /* discard crlf */
 				break;
 			/* Multi-bulk reply */
@@ -142,4 +144,3 @@ class Redis {
 	}
 	
 }
-		


### PR DESCRIPTION
This fixes fread warning when reading (GET something) empty string (SET something "").

$redisent->get("something");

A PHP Error was encountered
Severity: Warning
Message: fread(): Length parameter must be greater than 0
Filename: third_party/redisent.php
Line Number: 102
