### PR TITLE
Fix for fread usage when reading bulk reply

### DIFF
--- a/redisent.php
+++ b/redisent.php
@@ -99,8 +99,13 @@ class Redis {
 				if ($size > 0){
 					do {
 						$block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
-						$response .= fread($this->__sock, $block_size);
-						$read += $block_size;
+						$r = fread($this->__sock, $block_size);
+						if ($r === false) {
+							throw new \Exception('Failed to read response from stream');
+						} else {
+							$read += strlen($r);
+							$response .= $r;
+						}
 					} while ($read < $size);
 				}
 				fread($this->__sock, 2); /* discard crlf */
@@ -123,8 +128,13 @@ class Redis {
 						$block = "";
 						do {
 							$block_size = ($size - $read) > 1024 ? 1024 : ($size - $read);
-							$block .= fread($this->__sock, $block_size);
-							$read += $block_size;
+							$r = fread($this->__sock, $block_size);
+							if ($r === false) {
+								throw new \Exception('Failed to read response from stream');
+							} else {
+								$read += strlen($r);
+								$block .= $r;
+							}
 						} while ($read < $size);
 						fread($this->__sock, 2); /* discard crlf */
 						$response[] = $block;


### PR DESCRIPTION
I mentioned this in a comment yesterday: https://github.com/jdp/redisent/commit/62f739aaf8ce52fea53c3523353668d9bf5c9a39#-P0

Fixed error in fread usage - fread does not necessarily return the requested block size in network latency / buffered read situations, which caused the bulk reads to finish before the end of the data block.  Also catching a hard false response from fread and throwing a Failed Read exception.
