### PR TITLE
Now able to specify a connection timeout for new redis instances

### DIFF
--- a/src/redisent/Redis.php
+++ b/src/redisent/Redis.php
@@ -53,13 +53,15 @@ class Redis {
 	/**
 	 * Creates a Redisent connection to the Redis server at the address specified by {@link $dsn}.
 	 * The default connection is to the server running on localhost on port 6379.
-	 * @param string $dsn The data source name of the Redis server 
+	 * @param string $dsn The data source name of the Redis server
+	 * @param float $timeout The connection timeout in seconds
 	 */
-	function __construct($dsn = 'redis://localhost:6379') {
+	function __construct($dsn = 'redis://localhost:6379', $timeout = null) {
 		$this->dsn = parse_url($dsn);
 		$host = isset($this->dsn['host']) ? $this->dsn['host'] : 'localhost';
 		$port = isset($this->dsn['port']) ? $this->dsn['port'] : 6379;
-		$this->__sock = @fsockopen($host, $port, $errno, $errstr);
+		$timeout = $timeout ?: ini_get("default_socket_timeout");
+		$this->__sock = @fsockopen($host, $port, $errno, $errstr, $timeout);
 		if ($this->__sock === FALSE) {
 			throw new \Exception("{$errno} - {$errstr}");
 		}


### PR DESCRIPTION
As discussed I've added a second parameter to redisent\Redis() that accepts a timeout in seconds. If no timeout is passed then it defaults to the default_socket_timeout ini value so there should be no change in behaviour for existing users.

I've forgone writing a test for this particular piece of functionality due to the difficulties simulating and testing connection timeouts. Let me know if you've got any ideas on this front.
