### PR TITLE
composer: use psr0 autoload

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,6 @@
         "ext-sockets": "*"
     },
     "autoload": {
-        "classmap": ["src"]
+        "psr-0": {"redisent": "src"}
     }
 }


### PR DESCRIPTION
I didn't realize the code was in psr-0 structure, so classmap autoload is not needed.

Also could you register the package on https://packagist.org/packages/submit ? It would make it available in composer without knowing your github repository url.
